### PR TITLE
Add banner to bitmap output

### DIFF
--- a/src/out-bitmap.c
+++ b/src/out-bitmap.c
@@ -79,7 +79,6 @@ bitmap_out_banner(struct Output *out, FILE *fp, time_t timestamp,
 {
     UNUSEDPARM(fp);
     UNUSEDPARM(timestamp);
-    UNUSEDPARM(ip);
     UNUSEDPARM(ip_proto);
     UNUSEDPARM(port);
     UNUSEDPARM(proto);
@@ -87,7 +86,12 @@ bitmap_out_banner(struct Output *out, FILE *fp, time_t timestamp,
     UNUSEDPARM(px);
     UNUSEDPARM(length);
 
-    // Not used for bitmap so far
+    uint64_t idx = ip / 64;
+    uint64_t pos = 1ULL << (ip % 64);
+
+    atomic_fetch_or(&g_bmp[idx], pos);
+    atomic_fetch_add(&g_stats->recv, 1);
+
     out->rotate.bytes_written += 0;
 }
 
@@ -96,11 +100,9 @@ bitmap_out_banner(struct Output *out, FILE *fp, time_t timestamp,
  ****************************************************************************/
 const struct OutputType bitmap_output = {
     "bitmap",
-    0,
+    NULL,
     bitmap_out_open,
     bitmap_out_close,
     bitmap_out_status,
     bitmap_out_banner,
 };
-
-

--- a/src/out-bitmap.c
+++ b/src/out-bitmap.c
@@ -59,11 +59,11 @@ bitmap_out_status(struct Output *out, FILE *fp, time_t timestamp,
     UNUSEDPARM(reason);
     UNUSEDPARM(ttl);
 
-    uint64_t idx = ip / 64;
-    uint64_t pos = 1ULL << (ip % 64);
+    /* uint64_t idx = ip / 64; */
+    /* uint64_t pos = 1ULL << (ip % 64); */
 
-    atomic_fetch_or(&g_bmp[idx], pos);
-    atomic_fetch_add(&g_stats->recv, 1);
+    /* atomic_fetch_or(&g_bmp[idx], pos); */
+    /* atomic_fetch_add(&g_stats->recv, 1); */
 
     out->rotate.bytes_written += 0;
 }
@@ -83,14 +83,15 @@ bitmap_out_banner(struct Output *out, FILE *fp, time_t timestamp,
     UNUSEDPARM(port);
     UNUSEDPARM(proto);
     UNUSEDPARM(ttl);
-    UNUSEDPARM(px);
-    UNUSEDPARM(length);
 
-    uint64_t idx = ip / 64;
-    uint64_t pos = 1ULL << (ip % 64);
+    char *cmp = "XNTPD MON_GETLIST_1 ";
+    if (px != NULL && length > strlen(cmp) && (strstr((char *)px, cmp)) != NULL) {
+      uint64_t idx = ip / 64;
+      uint64_t pos = 1ULL << (ip % 64);
 
-    atomic_fetch_or(&g_bmp[idx], pos);
-    atomic_fetch_add(&g_stats->recv, 1);
+      atomic_fetch_or(&g_bmp[idx], pos);
+      atomic_fetch_add(&g_stats->recv, 1);
+    }
 
     out->rotate.bytes_written += 0;
 }


### PR DESCRIPTION
```
bin/masscan -pU:123 -oM filtered.bmp --seed 1337 --rate 10000 --append-output -c \
  files/masscan.conf -dd 60.15.234.166 --banners
```

```
% hexdump -C filtered.bmp                                                                                                                     00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
0781fd50  00 00 00 00 40 00 00 00  00 00 00 00 00 00 00 00  |....@...........|
0781fd60  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
20000000
```