### PR TITLE
Allow bitmap input

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -26,6 +26,11 @@
 #include "read-service-probes.h"
 #include <ctype.h>
 #include <limits.h>
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stdatomic.h>
+#include <sys/mman.h>
 
 #ifndef min
 #define min(a,b) ((a)<(b)?(a):(b))
@@ -427,6 +432,62 @@ ranges_from_file(struct RangeList *ranges, const char *filename)
      * before it can be used */
     rangelist_sort(ranges);
 }
+
+/*****************************************************************************
+ * Read in ranges from bmp
+ *****************************************************************************/
+static void
+ranges_from_bitmap(struct RangeList *ranges, const char *filename)
+{
+
+#define BITMAP_SIZE 512 * 1024 * 1024
+
+    FILE *fp;
+    errno_t err;
+
+    err = fopen_s(&fp, filename, "rt");
+    if (err) {
+        perror(filename);
+        exit(1); /* HARD EXIT: because if it's an exclusion file, we don't
+                  * want to continue. We don't want ANY chance of
+                  * accidentally scanning somebody */
+    }
+
+    void *addr;
+    if ((addr = mmap(NULL, BITMAP_SIZE, PROT_READ, MAP_PRIVATE, fileno(fp), 0)) == MAP_FAILED) {
+        perror("ranges_from_bitmap: mmap");
+        exit(1);
+    }
+
+    struct Range range;
+    uint64_t prev = 0xFFFFFFFFFFFFFFFF;
+    uint64_t ip = 0;
+    while (ip < 0x100000000ULL) {
+      uint64_t idx = ip / 64;
+      uint64_t isSet = (1ULL << (ip % 64)) & ((uint64_t*)addr)[idx];
+      if (isSet) {
+        if (prev == 0xFFFFFFFFFFFFFFFF || prev + 1 < ip) {
+          if (prev != 0xFFFFFFFFFFFFFFFF) {
+            range.end = prev;
+            rangelist_add_range(ranges, range.begin, range.end);
+            // printf("range: %ld - %ld\n", range.begin, range.end);
+          }
+          range.begin = ip;
+        }
+        prev = ip;
+      }
+      ip++;
+    }
+
+    munmap(addr, BITMAP_SIZE);
+    fclose(fp);
+
+    /* Target list must be sorted every time it's been changed,
+     * before it can be used */
+    rangelist_sort(ranges);
+    printf("ranges length = %llu\n", rangelist_count(ranges));
+}
+
 
 /***************************************************************************
  ***************************************************************************/
@@ -1848,25 +1909,30 @@ masscan_set_parameter(struct Masscan *masscan,
                || EQUALS("dst-ip", name) || EQUALS("dest-ip", name)
                || EQUALS("destination-ip", name)
                || EQUALS("target-ip", name)) {
-        const char *ranges = value;
-        unsigned offset = 0;
-        unsigned max_offset = (unsigned)strlen(ranges);
+        if (strlen(value) > 4 && !strcmp(&value[strlen(value) - 4], ".bmp")) {
+          LOG(5, "Input from bmp: %s\n", value);
+          ranges_from_bitmap(&masscan->targets, value);
+        } else {
+          const char *ranges = value;
+          unsigned offset = 0;
+          unsigned max_offset = (unsigned)strlen(ranges);
 
-        for (;;) {
-            struct Range range;
+          for (;;) {
+              struct Range range;
 
-            range = range_parse_ipv4(ranges, &offset, max_offset);
-            if (range.end < range.begin) {
-                fprintf(stderr, "ERROR: bad IP address/range: %s\n", ranges);
-                break;
-            }
+              range = range_parse_ipv4(ranges, &offset, max_offset);
+              if (range.end < range.begin) {
+                  fprintf(stderr, "ERROR: bad IP address/range: %s\n", ranges);
+                  break;
+              }
 
-            rangelist_add_range(&masscan->targets, range.begin, range.end);
+              rangelist_add_range(&masscan->targets, range.begin, range.end);
 
-            if (offset >= max_offset || ranges[offset] != ',')
-                break;
-            else
-                offset++; /* skip comma */
+              if (offset >= max_offset || ranges[offset] != ',')
+                  break;
+              else
+                  offset++; /* skip comma */
+          }
         }
         if (masscan->op == 0)
             masscan->op = Operation_Scan;

--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -1916,8 +1916,8 @@ masscan_set_parameter(struct Masscan *masscan,
                || EQUALS("dst-ip", name) || EQUALS("dest-ip", name)
                || EQUALS("destination-ip", name)
                || EQUALS("target-ip", name)) {
-        if (strlen(value) > 4 && !strcmp(&value[strlen(value) - 4], ".bmp")) {
-          LOG(5, "Input from bmp: %s\n", value);
+        if (strlen(value) > 4 && !strncmp(&value[strlen(value) - 4], ".bmp", 4)) {
+          printf("Input from bitmap: %s\n", value);
           ranges_from_bitmap(&masscan->targets, value);
         } else {
           const char *ranges = value;

--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -463,7 +463,7 @@ ranges_from_bitmap(struct RangeList *ranges, const char *filename)
       uint64_t idx = ip / 64;
       uint64_t isSet = (1ULL << (ip % 64)) & ((uint64_t*)addr)[idx];
       if (isSet) {
-        if (prev == 0xFFFFFFFFFFFFFFFF || prev + 1 < ip) {
+        if (prev == 0xFFFFFFFFFFFFFFFF || (prev + 1) < ip) {
           if (prev != 0xFFFFFFFFFFFFFFFF) {
             range.end = prev;
             if (range.end >= range.begin) {
@@ -477,6 +477,13 @@ ranges_from_bitmap(struct RangeList *ranges, const char *filename)
         prev = ip;
       }
       ip++;
+    }
+    // Add the last one
+    range.end = prev;
+    if (range.end >= range.begin) {
+      rangelist_add_range(ranges, range.begin, range.end);
+    } else {
+      printf("invalid range: %u - %u\n", range.begin, range.end);
     }
 
     munmap(addr, BITMAP_SIZE);

--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -26,10 +26,6 @@
 #include "read-service-probes.h"
 #include <ctype.h>
 #include <limits.h>
-#include <arpa/inet.h>
-#include <fcntl.h>
-#include <netinet/in.h>
-#include <stdatomic.h>
 #include <sys/mman.h>
 
 #ifndef min


### PR DESCRIPTION
Tested on my laptop.
```
jwan@~/Start/atlas/c/masscan (add-bitmap-input) $ make;sudo ./bin/masscan -pU:123 123.bmp --banners -oM 123.banner.bmp  --rate 8000000 --append-output
make: Nothing to be done for `all'.
Input from bitmap: 123.bmp
ranges length = 813535

Starting masscan 1.0.6 (http://bit.ly/14GZzcT) at 2018-12-27 23:22:33 GMT
 -- forced options: -sS -Pn -n --randomize-hosts -v --send-eth
Initiating SYN Stealth Scan
Scanning 813535 hosts [1 port/host]
^Cwaiting several seconds to exit...
^C^C:  0.00-kpps, 100.00% done, waiting 6-secs, found=0
ERROR: threads not exiting 1
^Cte:  0.00-kpps, 100.00% done, waiting 6-secs, found=0
ERROR: threads not exiting 2```