### PR TITLE
Ranges from txt file

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -488,7 +488,6 @@ ranges_from_bitmap(struct RangeList *ranges, const char *filename)
     /* Target list must be sorted every time it's been changed,
      * before it can be used */
     rangelist_sort(ranges);
-    printf("ranges length = %llu\n", rangelist_count(ranges));
 }
 
 
@@ -1915,6 +1914,11 @@ masscan_set_parameter(struct Masscan *masscan,
         if (strlen(value) > 4 && !strncmp(&value[strlen(value) - 4], ".bmp", 4)) {
           printf("Input from bitmap: %s\n", value);
           ranges_from_bitmap(&masscan->targets, value);
+          printf("ranges length = %llu\n", rangelist_count(&masscan->targets));
+        } else if (strlen(value) > 4 && !strncmp(&value[strlen(value) - 4], ".txt", 4)) {
+          printf("Input from txt: %s\n", value);
+          ranges_from_file(&masscan->targets, value);
+          printf("ranges length = %llu\n", rangelist_count(&masscan->targets));
         } else {
           const char *ranges = value;
           unsigned offset = 0;


### PR DESCRIPTION
```jwan@~/Start/atlas/c/masscan (add-txt-input) $ make;sudo ./bin/masscan -pU:123 123.bmp.iplist.txt --banners -oM 123.banner.bmp  --rate 8000000 --append-output
make: Nothing to be done for `all'.
Input from txt: 123.bmp.iplist.txt
ranges length = 813535

Starting masscan 1.0.6 (http://bit.ly/14GZzcT) at 2018-12-27 23:50:12 GMT
 -- forced options: -sS -Pn -n --randomize-hosts -v --send-eth
Initiating SYN Stealth Scan
Scanning 813535 hosts [1 port/host]
^Cwaiting several seconds to exit...
^C^C
ERROR: threads not exiting 1
^C
ERROR: threads not exiting 2
```

```
jwan@~/Start/atlas/c/masscan (add-txt-input) $ head 123.bmp.iplist.txt
1.0.137.125
1.0.138.13
1.0.143.10
1.0.143.182
1.0.145.0
1.0.145.60
1.0.145.129
1.0.146.31
1.0.147.180
1.0.151.63
```