### PR TITLE
handle empty bmp

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -453,14 +453,14 @@ ranges_from_bitmap(struct RangeList *ranges, const char *filename)
     }
 
     struct Range range;
-    uint64_t prev = 0xFFFFFFFFFFFFFFFF;
+    uint64_t prev = ULLONG_MAX;
     uint64_t ip = 0;
     while (ip < 0x100000000ULL) {
       uint64_t idx = ip / 64;
       uint64_t isSet = (1ULL << (ip % 64)) & ((uint64_t*)addr)[idx];
       if (isSet) {
-        if (prev == 0xFFFFFFFFFFFFFFFF || (prev + 1) < ip) {
-          if (prev != 0xFFFFFFFFFFFFFFFF) {
+        if (prev == ULLONG_MAX || (prev + 1) < ip) {
+          if (prev != ULLONG_MAX) {
             range.end = prev;
             if (range.end >= range.begin) {
               rangelist_add_range(ranges, range.begin, range.end);
@@ -475,11 +475,13 @@ ranges_from_bitmap(struct RangeList *ranges, const char *filename)
       ip++;
     }
     // Add the last one
-    range.end = prev;
-    if (range.end >= range.begin) {
-      rangelist_add_range(ranges, range.begin, range.end);
-    } else {
-      printf("invalid range: %u - %u\n", range.begin, range.end);
+    if (prev != ULLONG_MAX) {
+      range.end = prev;
+      if (range.end >= range.begin) {
+        rangelist_add_range(ranges, range.begin, range.end);
+      } else {
+        printf("invalid range: %u - %u\n", range.begin, range.end);
+      }
     }
 
     munmap(addr, BITMAP_SIZE);


### PR DESCRIPTION
If we input an empty bmp, like `test.bmp` here:
```
jwan@~/Start/atlas/c/masscan (handle-empty-bmp) $ sudo hexdump test.bmp
0000000 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
*
20000000
```

Before:
```
jwan@~/Start/atlas/c/masscan (master) $ make;sudo ./bin/masscan -pU:123  --banners -oM 123.banner.bmp  --rate 8000000 --append-output --includefile test.bmp
make: Nothing to be done for `all'.
Input from bitmap: test.bmp
ranges length = 3758096384
FAIL: range too big, need confirmation
 [hint] to prevent acccidents, at least one --exclude must be specified
 [hint] use "--exclude 255.255.255.255" as a simple confirmation
```

After:
```
jwan@~/Start/atlas/c/masscan (handle-empty-bmp) $ make;sudo ./bin/masscan -pU:123  --banners -oM 123.banner.bmp  --rate 8000000 --append-output --includefile test.bmp
make: Nothing to be done for `all'.
Input from bitmap: test.bmp
ranges length = 0
FAIL: target IP address list empty
 [hint] try something like "--range 10.0.0.0/8"
 [hint] try something like "--range 192.168.0.100-192.168.0.200"
```